### PR TITLE
fix patch image tree permission failure

### DIFF
--- a/.github/scripts/kubernetes.sh
+++ b/.github/scripts/kubernetes.sh
@@ -58,7 +58,8 @@ if [[ -n "$SEALOS_PATCH" ]]; then
   rmdir "$PATCH"
   sudo docker run --rm -v "/usr/bin:/pwd" --entrypoint /bin/sh ghcr.io/labring/sealos:latest -c "cp -a /usr/bin/sealos /pwd"
   sudo cp -au "$(sudo buildah mount "$(sudo buildah from "$SEALOS_PATCH-$ARCH")")" "$PATCH"
-  tree "$PATCH"
+  sudo chown -R "$(whoami)" "$PATCH"
+  tree "$PATCH" || true
   sudo cp -au "$PATCH"/* .
 else
   sudo docker run --rm -v "/usr/bin:/pwd" --entrypoint /bin/sh "$IMAGE_CACHE_NAME:sealos-v$SEALOS-amd64" -c "cp -a /sealos/sealos /pwd"


### PR DESCRIPTION
## Summary
- chown the copied patch image root before debug tree output so root-owned registry contents are readable by the runner
- make the debug tree output non-fatal; actual patch file copy still fails the build if it cannot copy required files

## Root Cause
The patch image is built in sealos lifecycle under lifecycle/docker/patch via save-cluster-images.sh. When runtime consumes sealosPatch, it copies the mounted patch image into /tmp/<runner>/patch with sudo and preserved ownership. The registry directory can remain root-owned, so plain tree /tmp/<runner>/patch exits with code 2 under set -e before the real copy/build step runs.

## Verification
- bash -n .github/scripts/kubernetes.sh .github/scripts/manifest.sh .github/scripts/versions/versions.sh .github/scripts/versions/versions_arch.sh